### PR TITLE
netboot: fixup for Nix 2 and recent changes

### DIFF
--- a/modules/netboot.nix
+++ b/modules/netboot.nix
@@ -79,7 +79,7 @@ with lib;
 
     # Create the squashfs image that contains the Nix store.
     system.build.squashfsStore = import "${pkgs.path}/nixos/lib/make-squashfs.nix" {
-      inherit (pkgs) stdenv squashfsTools perl pathsFromGraph;
+      inherit (pkgs) stdenv squashfsTools closureInfo;
       storeContents = config.netboot.storeContents;
     };
 


### PR DESCRIPTION
Fixes `nix-instantiate configuration.nix --show-trace` for me,
at least after running `./nix/update-ofborg-path.sh`.

Hope this helps!

There are other differences with upstream's netboot.nix,
but left this alone and just changed the part preventing eval.