### PR TITLE
Adds passwordless sudo to wheel + sudo auth.

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -141,6 +141,7 @@ in makeNetboot {
         challengeResponseAuthentication = false;
         passwordAuthentication = false;
       };
+      security.sudo.wheelNeedsPassword = false;
 
       boot.initrd.postMountCommands = "${persistence}";
       boot.postBootCommands = ''

--- a/users.nix
+++ b/users.nix
@@ -111,6 +111,7 @@ let
     };
 
     samueldr = {
+      sudo = true;
       trusted = true;
       keys = ./keys/samueldr;
     };


### PR DESCRIPTION
```
[15:31:04] <gchristensen> I'd like to make some people able to sudo in order to reboot the box or whatever to handle minor problems like out of disk space or whatever. anyone want to have this access?
[...]
[15:47:50] <samueldr> gchristensen: and to actually answer, interested, let's hope I never have to use it (except maybe for a garbage collection through reboot)
[15:48:07] <samueldr> (I mean, things are going well generally!)
[15:48:21] <gchristensen> mind sending a PR adding a "canSudo" flag to the user list, and making sudo passwordless? :)
[15:48:29] -*- samueldr notes for later
```

Now that we're later, it is done.

I did **not** add a `canSudo` flag since there was already a `sudo` flag; if the desire was to actually add another group for sudo purposes, I will amend the PR as required.