### PR TITLE
ssh: increase MaxSessions

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -152,6 +152,9 @@ in makeNetboot {
         enable = true;
         challengeResponseAuthentication = false;
         passwordAuthentication = false;
+        extraConfig = ''
+          MaxSessions 65
+        '';
       };
       security.sudo.wheelNeedsPassword = false;
 


### PR DESCRIPTION
This makes reuse of a single SSH connection for multiple builds more
useful (the default limit is 10), avoiding the need for
reauthenticating on each connection.
