### PR TITLE
Clone nixpkgs on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Finally, `nix-build . -A hello --option system aarch64-linux`.
 
 If this doesn't work, ping @grahamc and I can help debug.
 
+# Faster nixpkgs clone
+
+You may want to clone nixpkgs on the box occasionally. It clones nixpkgs on
+boot, allowing faster clones for users — just pass `--reference
+/tmp/nixpkgs.git` to your `git clone` command.
+
 ---
 
 ps: if you want to build the netbooted image, check out `./DEV_NOTES`

--- a/configuration.nix
+++ b/configuration.nix
@@ -269,6 +269,17 @@ in makeNetboot {
       in makeNBuilders 32;
     })
 
+    ({ pkgs, ... }: {
+      systemd.services.clone-nixpkgs = {
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network-online.target" ];
+        serviceConfig.Type = "oneshot";
+        script = ''
+          ${pkgs.git}/bin/git clone --bare https://github.com/nixos/nixpkgs /tmp/nixpkgs.git
+        '';
+      };
+    })
+
     ./users.nix
     ./monitoring.nix
     ./motd.nix


### PR DESCRIPTION
This allows getting a clone of nixpkgs significantly faster, using
$ git clone https://github.com/nixos/nixpkgs --reference /tmp/nixpkgs
which allows the majority of the objects to be fetched from the local
copy rather than github.

```
[lheckemann@aarch64:~]$ time git clone https://github.com/nixos/nixpkgs
Cloning into 'nixpkgs'...
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 1556267 (delta 1), reused 1 (delta 1), pack-reused 1556255
Receiving objects: 100% (1556267/1556267), 946.78 MiB | 28.35 MiB/s, done.
Resolving deltas: 100% (1066108/1066108), done.
Checking out files: 100% (19085/19085), done.

real    2m6.898s
user    4m40.698s
sys     0m19.442s

[lheckemann@aarch64:~]$ time git clone https://github.com/nixos/nixpkgs --reference nixpkgs nixpkgs2
Cloning into 'nixpkgs2'...
Checking connectivity: 1556267, done.
Checking out files: 100% (19085/19085), done.

real    0m24.238s
user    0m22.309s
sys     0m1.646s

```