### PR TITLE
Do not recommend overriding the currentSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMUTz5i9u5H2FHNAmZJyoJfIGyUm/HfGhfwnc142L3ds
 
 ***If it is not, please open an issue!***
 
-Finally, `nix-build . -A hello --option system aarch64-linux`.
+Finally, `nix-build . -A hello --argstr system aarch64-linux`.
 
 If this doesn't work, ping @grahamc and I can help debug.
 


### PR DESCRIPTION
This can cause issues. To quote [1] @cleverca22 on irc:

```
<clever> id recomend against using `--option system`, that will break a lot of things
<clever> if you use `--option system`, then your lying to nix that the LOCAL machine is aarch64, which causes builtins.currentSystem to repeat that lie, and nix will try to run aarch64 binaries (causing your issue)
<clever> if you use `--argstr system aarch64-linux`, then your telling nixpkgs to do an aarch64 build, and leaving the local arch intact
```

What we want to do here is to tell nix to build for aarch64. We can do
that by passing the `system` argument to the top-level default.nix in
nixpkgs. `--option system` will override `builtins.currentSystem`
instead, which will override the default value of the `system` argument
as well but will also change some other things we don't actually want to
change.

[1]https://logs.nix.samueldr.com/nixos/2020-04-08#3288014;