### PR TITLE
add bbigras as trusted user

### DIFF
--- a/keys/bbigras
+++ b/keys/bbigras
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH1cAOLonIDBdxnxscwTH/TC6DZg7ianGA0me+V9JWxv bbigras.aarch64.community.nixos

--- a/users.nix
+++ b/users.nix
@@ -48,6 +48,11 @@ let
       keys = keys/aszlig;
     };
 
+    bbigras = {
+      trusted = true;
+      keys = ./keys/bbigras;
+    };
+
     bennofs = {
       trusted = true;
       keys = ./keys/bennofs;


### PR DESCRIPTION
<!-- If you're not requesting access, delete the following: -->

I would like to be able to build my nix-on-droid config at the same time that I build/deploy my other systems with deploy-rs, please. I'm also thinking of getting a Raspberry Pi 4. [my nix-config](https://github.com/bbigras/nix-config).

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
