### PR TITLE
nixos unstable? yes

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -59,13 +59,15 @@ in makeNetboot {
     ({ pkgs, config, ...}: { # Hardware Tuning
       boot = {
         consoleLogLevel = 7;
-        initrd.availableKernelModules = [ "ahci" "pci_thunder_ecam" "hisi-rng" ];
+        initrd.availableKernelModules = [ "ahci" "hisi-rng" ];
 
         kernelParams = [
           "cma=0M" "biosdevname=0" "net.ifnames=0" "console=ttyAMA0,115200"
           "initrd=initrd"
         ];
         kernelPackages = pkgs.linuxPackages;
+        #
+        kernel.sysctl."kernel.hostname" = "${config.networking.hostName}.${config.networking.domain}";
       };
 
       nix.nrBuildUsers = config.nix.maxJobs * 2;
@@ -74,7 +76,8 @@ in makeNetboot {
     })
 
     ({ # Go fast: networking
-      networking.hostName = "aarch64.nixos.community";
+      networking.hostName = "aarch64";
+      networking.domain = "nixos.community";
       networking.dhcpcd.enable = false;
       networking.defaultGateway = {
         address = "147.75.77.189";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,7 @@ in import (hostpkgs.stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "NixOS";
-    repo = "nixpkgs-channels";
+    repo = "nixpkgs";
     inherit (srcDef) rev sha256;
   };
 

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,10 @@
 {
-  "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "808d3c6d12386009e1d1b8e8461d1e8d8fdc5ff1",
-  "date": "2019-12-07T12:22:09+01:00",
-  "sha256": "07d910k8q6q25vk67k2v8dnpn9b41mvc0rzqwlx9zddxqrdxa9bz",
-  "fetchSubmodules": false
+  "url": "https://github.com/nixos/nixpkgs.git",
+  "rev": "b3616bd96400ce0252c241d76fcafb64389defc6",
+  "date": "2021-01-15T23:18:51+01:00",
+  "path": "/nix/store/2i4273fksbnm7j6yvaqklbdb5i6742cm-nixpkgs",
+  "sha256": "04f1dzbm8ibrvs2a0n42d1qnvdwfhcdia9hmxydvb4aksmfnvrh7",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
 }

--- a/nix/update-nixpkgs.sh
+++ b/nix/update-nixpkgs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p nix-prefetch-git -I nixpkgs=channel:nixos-unstable-small
 
-REV=refs/heads/nixos-20.03
+REV=refs/heads/nixos-unstable-small
 
-nix-prefetch-git https://github.com/nixos/nixpkgs-channels.git \
+nix-prefetch-git https://github.com/nixos/nixpkgs.git \
                  --rev "$REV" > ./nix/nixpkgs.json

--- a/users.nix
+++ b/users.nix
@@ -37,7 +37,7 @@ let
       trusted = true;
       keys = ./keys/andir;
     };
-    
+
     angerman = {
       trusted = true;
       keys = ./keys/angerman;


### PR DESCRIPTION
This might update it to nixos-unstable-small. The removed kernel module is no longer available as a [module???](https://gist.github.com/Kiwi/1422804a89d68c1d93040209f2737b83) I don't know if it is necessary or not. Guess we'll find out. :smile: