### PR TITLE
Stick to stable nix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -175,8 +175,6 @@ in makeNetboot {
 
         trustedUsers = [ "@wheel" "@trusted" ];
 
-        package = pkgs.nixUnstable;
-
         useSandbox = true;
       };
     })
@@ -223,7 +221,7 @@ in makeNetboot {
           wantedBy = [ "multi-user.target" ];
 
           path = with pkgs; [
-            nixUnstable
+            nix
             git
             curl
             bash


### PR DESCRIPTION
This solves an issue with remote building from stable nix which is the
stable distribution of nix.

If users need the unstable Nix on the machine for local testing of their
flakes, ca-derivations, ... they can just nix-shell -p nixUnstable for
their experiments.

See also: https://github.com/NixOS/nix/issues/4664