### PR TITLE
add dguibert as trusted user

### DIFF
--- a/keys/dguibert
+++ b/keys/dguibert
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKyvjS9T3gos1M911q7kNU4M4i6VyiVX7Znsu4IfzIk/ dguibert@aarch64-build-box

--- a/users.nix
+++ b/users.nix
@@ -94,6 +94,11 @@ let
       keys = ./keys/dezgeg;
     };
 
+    dguibert = {
+      trusted = true;
+      keys = ./keys/dguibert;
+    };
+
     dhess = {
       trusted = true;
       keys = ./keys/dhess;


### PR DESCRIPTION
<!-- If you're not requesting access, delete the following: -->

- [X] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [X] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [X] I know when I can't trust the builder, as explained in the README
