### PR TITLE
Add @lukegb as trusted user

### DIFF
--- a/keys/lukegb
+++ b/keys/lukegb
@@ -1,0 +1,1 @@
+cert-authority,principals="lukegb" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEqNOwlR7Qa8cbGpDfSCOweDPbAGQOZIcoRgh6s/J8DR vault-clients

--- a/users.nix
+++ b/users.nix
@@ -237,6 +237,11 @@ let
       keys = ./keys/lovesegfault;
     };
 
+    lukegb = {
+      trusted = true;
+      keys = ./keys/lukegb;
+    };
+
     ma27 = {
       trusted = true;
       keys = ./keys/ma27;


### PR DESCRIPTION
I sometimes need to test things on aarch64-linux and I _still_ haven't
gotten around to setting up my Oracle Cloud machine...

* [x]  I have read the entire README https://github.com/nix-community/aarch64-build-box
* [x]  I completely understood the README https://github.com/nix-community/aarch64-build-box
* [x]  I know when I can't trust the builder, as explained in the README
