### PR TITLE
add artturin as trusted user

### DIFF
--- a/keys/artturin
+++ b/keys/artturin
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPJiUxvklqkkqhqUAsyQy1fnGYB2ICqCrxFZn4pf6G1o artturin@aarch64-build-box

--- a/users.nix
+++ b/users.nix
@@ -43,6 +43,11 @@ let
       keys = ./keys/angerman;
     };
 
+    artturin = {
+      trusted = true;
+      keys = ./keys/artturin;
+    };
+
     aszlig = {
       trusted = true;
       keys = keys/aszlig;


### PR DESCRIPTION
<!-- If you're not requesting access, delete the following: -->

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
