### PR TITLE
Apply kernel personality patch from Ubuntu and configure armv7l support.

### DIFF
--- a/armv7l.nix
+++ b/armv7l.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+{
+  boot.kernelPatches = [
+    rec {
+      name = "compat_uts_machine";
+      patch = pkgs.fetchpatch {
+        inherit name;
+        url = "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/jammy/patch/?id=c1da50fa6eddad313360249cadcd4905ac9f82ea";
+        sha256 = "sha256-mpq4YLhobWGs+TRKjIjoe5uDiYLVlimqWUCBGFH/zzU=";
+      };
+    }
+  ];
+  boot.kernelParams = [
+    "compat_uts_machine=armv7l"
+  ];
+  nix.extraOptions = "extra-platforms = armv7l-linux";
+}

--- a/configuration.nix
+++ b/configuration.nix
@@ -276,5 +276,6 @@ in makeNetboot {
     ./users.nix
     ./monitoring.nix
     ./motd.nix
+    ./armv7l.nix
   ];
 }


### PR DESCRIPTION
This patch along with [changes in nix](https://github.com/NixOS/nix/pull/5276) should allow to use aarch64 machines as armv7l builders.
See also https://github.com/NixOS/nixpkgs/pull/25240#issuecomment-1146564193

<!-- If you're not requesting access, delete the following: -->

- [X] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [X] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [X] I know when I can't trust the builder, as explained in the README

CC @lheckemann @grahamc 