### PR TITLE
add lily to trusted users

### DIFF
--- a/keys/lily
+++ b/keys/lily
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKYH3ivyXgnhXL6xgZxZifRclw+2xsxWNdNe1ghjw7A lily@bina

--- a/users.nix
+++ b/users.nix
@@ -263,6 +263,11 @@ let
       keys = ./keys/lheckemann;
     };
 
+    lily = {
+      trusted = true;
+      keys = ./keys/lily;
+    };
+
     lnl = {
       trusted = true;
       keys = ./keys/lnl;


### PR DESCRIPTION
- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README

I've been doing a lot more testing on aarch64 for my nixpkgs work, but the only aarch64 system I actually have is a Raspberry Pi. So it would be lovely to be able to use the community builder for testing some of that work

Thank you!