### PR TITLE
configuration: enable nix-serve service with nix-serve-ng

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -152,6 +152,12 @@ in makeNetboot {
       };
       security.sudo.wheelNeedsPassword = false;
 
+      services.nix-serve = {
+        enable = true;
+        packages = pkgs.haskellPackages.nix-serve-ng;
+        openFirewall = true;
+      };
+
       boot.supportedFilesystems = [ "zfs" ];
       boot.initrd.postDeviceCommands = "${postDeviceCommands}";
       boot.initrd.postMountCommands = "${postMountCommands}";


### PR DESCRIPTION
It is convenient to be able to use this box as a substituter when developing for mobile-nixos, to avoid having to install keys on the devices

<!-- If you're not requesting access, delete the following: -->

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
