### PR TITLE
add raitobezarius as trusted user

### DIFF
--- a/keys/raitobezarius
+++ b/keys/raitobezarius
@@ -1,0 +1,2 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA3hCOyFwuoCLt5W9e9yQSwj9I+VspB0kNNHsoFngbgZ remote-builder@thors
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF07Sy0O+oletFYlrfS0+XtBWJO2F+Rc9J/ocNLBa/OE remote-builder@thorkell

--- a/users.nix
+++ b/users.nix
@@ -377,6 +377,11 @@ let
       keys = ./keys/r-burns;
     };
 
+    raitobezarius = {
+      trusted = true;
+      keys = ./keys/raitobezarius;
+    };
+
     rnhmjoj = {
       trusted = true;
       keys = ./keys/rnhmjoj;


### PR DESCRIPTION
I am working on https://github.com/nix-community/lanzaboote/pull/31 and this machine seems to have nested virt, this would be useful for tests :).

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
