### PR TITLE
netboot: fixup

### DIFF
--- a/armv7l.nix
+++ b/armv7l.nix
@@ -6,7 +6,7 @@
       patch = pkgs.fetchpatch {
         inherit name;
         url = "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/jammy/patch/?id=c1da50fa6eddad313360249cadcd4905ac9f82ea";
-        sha256 = "sha256-mpq4YLhobWGs+TRKjIjoe5uDiYLVlimqWUCBGFH/zzU=";
+        sha256 = "sha256-357+EzMLLt7IINdH0ENE+VcDXwXJMo4qiF/Dorp2Eyw=";
       };
     }
   ];

--- a/modules/netboot.nix
+++ b/modules/netboot.nix
@@ -59,7 +59,7 @@ with lib;
 
     # Create the squashfs image that contains the Nix store.
     system.build.squashfsStore = import "${pkgs.path}/nixos/lib/make-squashfs.nix" {
-      inherit (pkgs) stdenv squashfsTools closureInfo;
+      inherit (pkgs) lib stdenv squashfsTools closureInfo;
       storeContents = config.netboot.storeContents;
     };
 


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/91dd8b932457a45f08be3d4d355c12cbb1703774, `make-squashfs.nix` takes a `lib` argument as well.

<!-- If you're not requesting access, delete the following: -->

- [ ] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [ ] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [ ] I know when I can't trust the builder, as explained in the README
