### PR TITLE
configuration: don't log refused connections

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -92,6 +92,8 @@ in makeNetboot {
         "147.75.207.208"
       ];
 
+      networking.firewall.logRefusedConnections = false;
+
       networking.bonds.bond0 = {
         driverOptions = {
           mode = "802.3ad";


### PR DESCRIPTION
<!-- If you're not requesting access, delete the following: -->

- [ ] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [ ] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [ ] I know when I can't trust the builder, as explained in the README
