### PR TITLE
Revert "post-devices.sh: add the other NVMe device to the pool as well"

### DIFF
--- a/post-devices.sh
+++ b/post-devices.sh
@@ -37,7 +37,6 @@ zpool \
     -O relatime=on \
     -o ashift=12 \
     rpool \
-    /dev/nvme0n1p2 \
-    /dev/nvme1n1
+    /dev/nvme0n1p2
 
 zfs create -o mountpoint=legacy rpool/root


### PR DESCRIPTION
Reverts nix-community/aarch64-build-box#170

---

Probably causing the recent kernel panics that locks everything up. Gonna try and get this deployed so that ofborg can catch up in its aarch64 queue (and I don't have to keep rebooting the box every ~900 seconds, according to dmesg).