### PR TITLE
Revert "Revert "post-devices.sh: add the other NVMe device to the pool as well""

### DIFF
--- a/post-devices.sh
+++ b/post-devices.sh
@@ -37,6 +37,7 @@ zpool \
     -O relatime=on \
     -o ashift=12 \
     rpool \
-    /dev/nvme0n1p2
+    /dev/nvme0n1p2 \
+    /dev/nvme1n1
 
 zfs create -o mountpoint=legacy rpool/root


### PR DESCRIPTION
Reverts nix-community/aarch64-build-box#173

---

Still happens without this so let's bring it back for more disk space, if the machine ever lives for more than 10 minutes.