### PR TITLE
configuration: try newer kernel

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -65,7 +65,8 @@ in makeNetboot {
           "cma=0M" "biosdevname=0" "net.ifnames=0" "console=ttyAMA0,115200"
           "initrd=initrd"
         ];
-        kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
+        zfs.removeLinuxDRM = true;
+        kernelPackages = (config.boot.zfs.package.override { removeLinuxDRM = true; }).latestCompatibleLinuxPackages;
         #
         kernel.sysctl."kernel.hostname" = "${config.networking.hostName}.${config.networking.domain}";
       };

--- a/configuration.nix
+++ b/configuration.nix
@@ -65,7 +65,7 @@ in makeNetboot {
           "cma=0M" "biosdevname=0" "net.ifnames=0" "console=ttyAMA0,115200"
           "initrd=initrd"
         ];
-        kernelPackages = pkgs.linuxPackages_5_15;
+        kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
         #
         kernel.sysctl."kernel.hostname" = "${config.networking.hostName}.${config.networking.domain}";
       };

--- a/configuration.nix
+++ b/configuration.nix
@@ -287,6 +287,6 @@ in makeNetboot {
     ./users.nix
     ./monitoring.nix
     ./motd.nix
-    ./armv7l.nix
+    # ./armv7l.nix
   ];
 }


### PR DESCRIPTION
ZFS has been unhappy:

    [ 1651.223265] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000000
    [ 1651.232075] Mem abort info:
    [ 1651.234875]   ESR = 0x0000000096000006
    [ 1651.238613]   EC = 0x25: DABT (current EL), IL = 32 bits
    [ 1651.243915]   SET = 0, FnV = 0
    [ 1651.246959]   EA = 0, S1PTW = 0
    [ 1651.250089]   FSC = 0x06: level 2 translation fault
    [ 1651.254957] Data abort info:
    [ 1651.257826]   ISV = 0, ISS = 0x00000006
    [ 1651.261651]   CM = 0, WnR = 0
    [ 1651.264605] user pgtable: 4k pages, 48-bit VAs, pgdp=00000833fde29000
    [ 1651.271035] [0000000000000000] pgd=08000822bdb9f003, p4d=08000822bdb9f003, pud=080008384e1c3003, pmd=0000000000000000
    [ 1651.281635] Internal error: Oops: 0000000096000006 [#1] SMP
    [ 1651.287196] Modules linked in: nhpoly1305_neon nhpoly1305 chacha_generic chacha_neon libchacha adiantum libpoly1305 camellia_generic cast5_generic cast_common des_generic libdes blowfish_generic blowfish_common serpent_generic xts cbc twofish_generic twofish_common ecb lrw algif_skcipher af_alg cfg80211 rfkill mlx5_ib ib_uverbs ib_core arm_spe_pmu crct10dif_ce acpi_ipmi ipmi_ssif mlx5_core ast drm_vram_helper drm_ttm_helper ttm drm_kms_helper mlxfw psample ipmi_devintf xgene_hwmon arm_cmn ipmi_msghandler arm_dmc620_pmu cppc_cpufreq arm_dsu_pmu acpi_tad ip6_tables xt_conntrack nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_tcpudp ip6t_rpfilter ipt_rpfilter xt_pkttype nft_compat nft_counter sch_fq_codel nf_tables libcrc32c nfnetlink bonding tls fuse drm dmi_sysfs ip_tables x_tables nvme nvme_core xhci_pci xhci_pci_renesas dm_mod zfs(PO) spl(O) overlay
    [ 1651.362341] CPU: 78 PID: 1629683 Comm: rm Tainted: P           O      5.15.137 #1-NixOS
    [ 1651.370332] Hardware name: GIGABYTE R272-P30-JG/MP32-AR0-JG, BIOS F17a (SCP: 1.07.20210713) 07/22/2021
    [ 1651.379624] pstate: 00400009 (nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
    [ 1651.386573] pc : arc_buf_destroy+0x2c/0x160 [zfs]
    [ 1651.391392] lr : dbuf_undirty+0x35c/0x3b0 [zfs]
    [ 1651.396018] sp : ffff8000ad5a3910
    [ 1651.399320] x29: ffff8000ad5a3910 x28: ffff0819cc73c620 x27: 0000000000000000
    [ 1651.406443] x26: ffff08246cc2a000 x25: 0000000000000000 x24: ffff08257cd99710
    [ 1651.413565] x23: 0000000000000028 x22: 0000000000000000 x21: 0000000000000000
    [ 1651.420688] x20: ffff0819cc73c620 x19: ffff081f42d88a00 x18: ffffffffffffffff
    [ 1651.427810] x17: 0000000000000000 x16: ffffc7961b373c94 x15: 00af0000b6bb0c30
    [ 1651.434932] x14: 006b0000b56eae10 x13: 0000000000000005 x12: 0000000000000000
    [ 1651.442055] x11: 0000000000000000 x10: 0000000000000001 x9 : ffffc7960e14e240
    [ 1651.449178] x8 : ffff8000ad5a3850 x7 : 0000000000000000 x6 : 0000000000000040
    [ 1651.456300] x5 : 0000000000000000 x4 : ffff08320c27cb00 x3 : ffff081f42d896d0
    [ 1651.463423] x2 : 0000000000000000 x1 : ffffc7960e38f4c0 x0 : 0000000000000000
    [ 1651.470545] Call trace:
    [ 1651.472980]  arc_buf_destroy+0x2c/0x160 [zfs]
    [ 1651.477434]  dbuf_undirty+0x35c/0x3b0 [zfs]
    [ 1651.481708]  dbuf_free_range+0x130/0x3fc [zfs]
    [ 1651.486247]  dnode_free_range+0x198/0x6c0 [zfs]
    [ 1651.490873]  dmu_free_long_range+0x354/0x55c [zfs]
    [ 1651.495756]  zfs_rmnode+0x314/0x4ac [zfs]
    [ 1651.499860]  zfs_zinactive+0x160/0x1b0 [zfs]
    [ 1651.504222]  zfs_inactive+0x80/0x234 [zfs]
    [ 1651.508412]  zpl_evict_inode+0x4c/0x70 [zfs]
    [ 1651.512773]  evict+0xe0/0x220
    [ 1651.515730]  iput+0x154/0x280
    [ 1651.518685]  do_unlinkat+0x1c4/0x2c0
    [ 1651.522249]  __arm64_sys_unlinkat+0x44/0x90
    [ 1651.526420]  invoke_syscall+0x50/0x120
    [ 1651.530160]  el0_svc_common.constprop.0+0xd4/0xf4
    [ 1651.534851]  do_el0_svc+0x2c/0xa0
    [ 1651.538154]  el0_svc+0x28/0xb0
    [ 1651.541199]  el0t_64_sync_handler+0xe8/0x114
    [ 1651.545457]  el0t_64_sync+0x1a0/0x1a4
    [ 1651.549108] Code: 91120021 91010021 a9025bf5 aa0003f5 (f9400014)
    [ 1651.555188] ---[ end trace 855ad177572850d6 ]---

<!-- If you're not requesting access, delete the following: -->

- [ ] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [ ] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [ ] I know when I can't trust the builder, as explained in the README

---

cc https://github.com/nix-community/aarch64-build-box/pull/152